### PR TITLE
[warnings] remove ml_z_mul_overflows warnings for zarith >= 1.12

### DIFF
--- a/runtime.js
+++ b/runtime.js
@@ -1110,3 +1110,8 @@ function ml_z_bin(n, k){
   return ml_z_normalize(coeff);
 
 }
+
+//Provides: ml_z_mul_overflows
+function ml_z_mul_overflows(_vx, _vy){
+  return true;
+}


### PR DESCRIPTION
version 1.12 of zarith introduces a new primitive not exported in z.mli: ml_z_mul_overflows.
This primitive is only used in ml_z_mul and not useful in the javascript
stubs since these overflows are taken care of in biginteger.js.
This commit just adds a dummy ml_z_mul_overflows to silence the warnings.